### PR TITLE
Configurable EC2 endpoints & updates sdk/gatling versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The plugin expects that the access/secret key are provided at runtime to interac
 
 Create a new Maven project that follows the following structure:
 
-1. Create a Gatling simulation (e.g. com.FooTest) in `src/test/scala/com/FooTest.scala`. See <a href="http://gatling.io/docs/2.1.7/general/concepts.html">the Gatling concepts docs</a> for more information.
-2. Put a gatling.conf and logback.xml file in `src/test/resources`. See <a href="http://gatling.io/docs/2.1.7/general/configuration.html">the Gatling configuration docs</a> for more information.
+1. Create a Gatling simulation (e.g. com.FooTest) in `src/test/scala/com/FooTest.scala`. See <a href="http://gatling.io/docs/2.2.0/general/concepts.html">the Gatling concepts docs</a> for more information.
+2. Put a gatling.conf and logback.xml file in `src/test/resources`. See <a href="http://gatling.io/docs/2.2.0/general/configuration.html">the Gatling configuration docs</a> for more information.
 3. Create a `install-gatling.sh` script in `src/test/resources` This script will run on each load generator to install Gatling and do any other setup necessary before starting your test. Make sure **the script is executable** and looks similar to the following:
 
 ```
@@ -80,7 +80,7 @@ sudo yum remove  --quiet --assumeyes java-1.7.0-openjdk.x86_64
 sudo yum install --quiet --assumeyes java-1.8.0-openjdk-devel.x86_64 htop screen
 
 # Install Gatling
-GATLING_VERSION=2.1.7
+GATLING_VERSION=2.2.0
 URL=https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/${GATLING_VERSION}/gatling-charts-highcharts-bundle-${GATLING_VERSION}-bundle.zip
 GATLING_ARCHIVE=gatling-charts-highcharts-bundle-${GATLING_VERSION}-bundle.zip
 
@@ -95,8 +95,8 @@ rm -rf gatling-charts-highcharts-bundle-${GATLING_VERSION}/user-files/simulation
 
 ```xml
   <properties>
-    <gatling.version>2.1.7</gatling.version>
-    <gatling-plugin.version>2.1.7</gatling-plugin.version>
+    <gatling.version>2.2.0</gatling.version>
+    <gatling-plugin.version>2.2.0</gatling-plugin.version>
     <gatling.skip>false</gatling.skip>
 
     <!-- Information required to start EC2 instances and control them via SSH -->
@@ -105,9 +105,9 @@ rm -rf gatling-charts-highcharts-bundle-${GATLING_VERSION}/user-files/simulation
     <ec2.security.group>default</ec2.security.group>
     <ec2.instance.count>1</ec2.instance.count>
 
-    <gatling.local.home>${project.basedir}/gatling/gatling-charts-highcharts-bundle-2.1.7/bin/gatling.sh</gatling.local.home>
+    <gatling.local.home>${project.basedir}/gatling/gatling-charts-highcharts-bundle-2.2.0/bin/gatling.sh</gatling.local.home>
     <gatling.install.script>${project.basedir}/src/test/resources/install-gatling.sh</gatling.install.script>
-    <gatling.root>gatling-charts-highcharts-bundle-2.1.7</gatling.root>
+    <gatling.root>gatling-charts-highcharts-bundle-2.2.0</gatling.root>
     <gatling.java.opts> -Xms1g -Xmx25g -Xss8M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M</gatling.java.opts>
 
     <!-- Fully qualified name of the Gatling simulation and a name describing the test -->

--- a/examples/maven-example-loadtest-project/downloadGatling.sh
+++ b/examples/maven-example-loadtest-project/downloadGatling.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-GATLING_VERSION=2.1.7
+GATLING_VERSION=2.2.0
 
 mkdir -p gatling
 cd gatling

--- a/examples/maven-example-loadtest-project/pom.xml
+++ b/examples/maven-example-loadtest-project/pom.xml
@@ -17,17 +17,17 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<gatling.version>2.1.7</gatling.version>
-		<gatling-plugin.version>2.1.7</gatling-plugin.version>
+		<gatling.version>2.2.0</gatling.version>
+		<gatling-plugin.version>2.2.0</gatling-plugin.version>
 		<gatling.skip>false</gatling.skip>
 		<!-- Information required to start EC2 instances and control them via SSH -->
 		<ssh.private.key>${user.home}/.ssh/loadtest-keypair.pem</ssh.private.key>
 		<ec2.key.pair.name>loadtest-keypair</ec2.key.pair.name>
 		<ec2.security.group>gatling-security-group</ec2.security.group>
 		<ec2.instance.count>1</ec2.instance.count>
-		<gatling.local.home>${project.basedir}/gatling/gatling-charts-highcharts-bundle-2.1.7/bin/gatling.sh</gatling.local.home>
+		<gatling.local.home>${project.basedir}/gatling/gatling-charts-highcharts-bundle-2.2.0/bin/gatling.sh</gatling.local.home>
 		<gatling.install.script>${project.basedir}/src/test/resources/install-gatling.sh</gatling.install.script>
-		<gatling.root>gatling-charts-highcharts-bundle-2.1.7</gatling.root>
+		<gatling.root>gatling-charts-highcharts-bundle-2.2.0</gatling.root>
 		<gatling.java.opts>-Xms1g -Xmx4g</gatling.java.opts>
 		<!-- Fully qualified name of the Gatling simulation and a name describing 
 			the test -->

--- a/examples/maven-example-loadtest-project/src/test/resources/install-gatling.sh
+++ b/examples/maven-example-loadtest-project/src/test/resources/install-gatling.sh
@@ -11,7 +11,7 @@ sudo yum remove  --quiet --assumeyes java-1.7.0-openjdk.x86_64
 sudo yum install --quiet --assumeyes java-1.8.0-openjdk-devel.x86_64 htop screen
 
 # Install Gatling
-GATLING_VERSION=2.1.7
+GATLING_VERSION=2.2.0
 URL=https://repo1.maven.org/maven2/io/gatling/highcharts/gatling-charts-highcharts-bundle/${GATLING_VERSION}/gatling-charts-highcharts-bundle-${GATLING_VERSION}-bundle.zip
 GATLING_ARCHIVE=gatling-charts-highcharts-bundle-${GATLING_VERSION}-bundle.zip
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
     <packaging>maven-plugin</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <gatling.version>2.1.6</gatling.version>
-        <gatling-plugin.version>2.1.6</gatling-plugin.version>
-        <aws.version>1.10.52</aws.version>
+        <gatling.version>2.2.0</gatling.version>
+        <gatling-plugin.version>2.2.0</gatling-plugin.version>
+        <aws.version>1.10.75</aws.version>
     </properties>
     <licenses>
         <license>

--- a/src/main/java/com/ea/gatling/AwsGatlingRunner.java
+++ b/src/main/java/com/ea/gatling/AwsGatlingRunner.java
@@ -25,13 +25,14 @@ public class AwsGatlingRunner {
     private final AmazonEC2Client ec2client;
     private TransferManager transferManager;
 
-    public AwsGatlingRunner() {
+    public AwsGatlingRunner(final String endpoint) {
         final AWSCredentialsProviderChain credentials = new AWSCredentialsProviderChain(new EnvironmentVariableCredentialsProvider(),
                 new SystemPropertiesCredentialsProvider(),
                 new ProfileCredentialsProvider(),
                 new InstanceProfileCredentialsProvider(),
                 new PropertiesFileCredentialsProvider("aws.properties"));
         ec2client = new AmazonEC2Client(credentials);
+        ec2client.setEndpoint(endpoint);
         transferManager = new TransferManager(credentials);
     }
 

--- a/src/main/java/com/ea/gatling/GatlingAwsMojo.java
+++ b/src/main/java/com/ea/gatling/GatlingAwsMojo.java
@@ -58,6 +58,9 @@ public class GatlingAwsMojo extends AbstractMojo {
     @Parameter(property = "ec2.keep.alive", defaultValue="false")
     private boolean ec2KeepAlive = false;
 
+    @Parameter(property = "ec2.end.point", defaultValue="https://ec2.us-east-1.amazonaws.com")
+    private String ec2EndPoint;
+
     @Parameter(property = "ssh.private.key", defaultValue = "${user.home}/gatling-private-key.pem")
     private File sshPrivateKey;
 
@@ -116,7 +119,7 @@ public class GatlingAwsMojo extends AbstractMojo {
     private String s3Subfolder;
 
     public void execute() throws MojoExecutionException {
-        AwsGatlingRunner runner = new AwsGatlingRunner();
+        AwsGatlingRunner runner = new AwsGatlingRunner(ec2EndPoint);
 
         Map<String, Instance> instances = runner.launchEC2Instances(instanceType, instanceCount, ec2KeyPairName, ec2SecurityGroup, ec2AmiId);
         ConcurrentHashMap<String, Boolean> successfulHosts = new ConcurrentHashMap<String, Boolean>();


### PR DESCRIPTION
I took he liberty of updating the version numbers of gatling and the AWS sdk.

If you wish to cherry pick, only the Java modifications are required. AwsGatlingRunner.java / GatlingAwsMojo.java
