### PR TITLE
Add support for custom ssh user when connecting to ec2 instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ rm -rf gatling-charts-highcharts-bundle-${GATLING_VERSION}/user-files/simulation
     <gatling.skip>false</gatling.skip>
 
     <!-- Information required to start EC2 instances and control them via SSH -->
+    <ssh.user>ec2-user</ssh.user>
     <ssh.private.key>${user.home}/.ssh/loadtest.pem</ssh.private.key>
     <ec2.key.pair.name>loadtest-keypair</ec2.key.pair.name>
     <ec2.security.group>default</ec2.security.group>

--- a/examples/maven-example-loadtest-project/pom.xml
+++ b/examples/maven-example-loadtest-project/pom.xml
@@ -21,6 +21,7 @@
 		<gatling-plugin.version>2.2.4</gatling-plugin.version>
 		<gatling.skip>false</gatling.skip>
 		<!-- Information required to start EC2 instances and control them via SSH -->
+        <ssh.user>ec2-user</ssh.user>
 		<ssh.private.key>${user.home}/.ssh/loadtest-keypair.pem</ssh.private.key>
 		<ec2.key.pair.name>loadtest-keypair</ec2.key.pair.name>
 		<ec2.security.group>gatling-security-group</ec2.security.group>

--- a/src/main/java/com/ea/gatling/AwsGatlingExecutor.java
+++ b/src/main/java/com/ea/gatling/AwsGatlingExecutor.java
@@ -13,11 +13,11 @@ import java.util.stream.Collectors;
 
 public class AwsGatlingExecutor implements Runnable {
 
-    private static final String SSH_USER = "ec2-user";
     private static final String[] GATLING_RESOURCES = {"data", "bodies"};
     private static final String DEFAULT_JVM_ARGS = "-Dsun.net.inetaddr.ttl=60";
 
     private final String host;
+    private final String sshUser;
     private final String sshPrivateKey;
     private final String testName;
     private final File installScript;
@@ -35,8 +35,9 @@ public class AwsGatlingExecutor implements Runnable {
     private final String inheritedGatlingJavaOpts;
     private final boolean debugOutputEnabled;
 
-    public AwsGatlingExecutor(String host, File sshPrivateKey, String testName, File installScript, File gatlingSourceDir, String gatlingSimulation, File simulationConfig, Map<String, String> simulationOptions, File gatlingResourcesDir, File gatlingLocalResultsDir, List<String> additionalFiles, int numInstance, int instanceCount, ConcurrentHashMap<String, Integer> completedHosts, String gatlingRoot, String inheritedGatlingJavaOpts, boolean debugOutputEnabled) {
+    public AwsGatlingExecutor(String host,String sshUser, File sshPrivateKey, String testName, File installScript, File gatlingSourceDir, String gatlingSimulation, File simulationConfig, Map<String, String> simulationOptions, File gatlingResourcesDir, File gatlingLocalResultsDir, List<String> additionalFiles, int numInstance, int instanceCount, ConcurrentHashMap<String, Integer> completedHosts, String gatlingRoot, String inheritedGatlingJavaOpts, boolean debugOutputEnabled) {
         this.host = host;
+        this.sshUser = sshUser;
         this.sshPrivateKey = sshPrivateKey.getAbsolutePath();
         this.testName = testName;
         this.installScript = installScript;
@@ -57,7 +58,7 @@ public class AwsGatlingExecutor implements Runnable {
 
     public void runGatlingTest() throws IOException {
         log("started");
-        final SshClient.HostInfo hostInfo = new SshClient.HostInfo(host, SSH_USER, sshPrivateKey);
+        final SshClient.HostInfo hostInfo = new SshClient.HostInfo(host, sshUser, sshPrivateKey);
 
         // copy scripts
         SshClient.scpUpload(hostInfo, new SshClient.FromTo(installScript.getAbsolutePath(), ""));

--- a/src/main/java/com/ea/gatling/GatlingAwsMojo.java
+++ b/src/main/java/com/ea/gatling/GatlingAwsMojo.java
@@ -79,6 +79,9 @@ public class GatlingAwsMojo extends AbstractMojo {
     @Parameter(property = "ssh.private.key", defaultValue = "${user.home}/gatling-private-key.pem")
     private File sshPrivateKey;
 
+    @Parameter(property = "ssh.user", defaultValue = "ec2-user")
+    private String sshUser;
+
     @Parameter(property = "debug.output.enabled", defaultValue = "false")
     private boolean debugOutputEnabled = false;
 
@@ -163,6 +166,7 @@ public class GatlingAwsMojo extends AbstractMojo {
             String host = getPreferredHostName(instance);
             Runnable worker = new AwsGatlingExecutor(
                     host,
+                    sshUser,
                     sshPrivateKey,
                     testName,
                     installScript,


### PR DESCRIPTION
Hi there, I had trouble when using the plugin since the ssh user name is hard coded.
This pull request allow for ssh username customization in the maven standard way like the other properties. (sshUser in plugin configuration, -Dssh.user=xxx for cli, default value to ec2-user)
HTH