### PR TITLE
Run Detached and have a Kill Mojo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gatling-aws-maven-plugin</artifactId>
     <groupId>com.ea.gatling</groupId>
-    <version>1.0.18-SNAPSHOT</version>
+    <version>1.0.19-SNAPSHOT</version>
     <name>Gatling AWS Maven Plugin</name>
     <description>The Gatling AWS Maven plugin takes the pain out of scaling up your Gatling tests. It runs your load test on a configurable number of EC2 instances, aggregates a single load test report, and uploads the results to S3. All EC2 instances are terminated at the end of the test to ensure you are only paying for what you need.</description>
     <url>https://github.com/electronicarts/gatling-aws-maven-plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>gatling-aws-maven-plugin</artifactId>
     <groupId>com.ea.gatling</groupId>
-    <version>1.0.19-SNAPSHOT</version>
+    <version>1.0.18-SNAPSHOT</version>
     <name>Gatling AWS Maven Plugin</name>
     <description>The Gatling AWS Maven plugin takes the pain out of scaling up your Gatling tests. It runs your load test on a configurable number of EC2 instances, aggregates a single load test report, and uploads the results to S3. All EC2 instances are terminated at the end of the test to ensure you are only paying for what you need.</description>
     <url>https://github.com/electronicarts/gatling-aws-maven-plugin</url>

--- a/src/main/java/com/ea/gatling/AwsGatlingExecutor.java
+++ b/src/main/java/com/ea/gatling/AwsGatlingExecutor.java
@@ -33,9 +33,8 @@ public class AwsGatlingExecutor implements Runnable {
     private final String inheritedGatlingJavaOpts;
     private final boolean debugOutputEnabled;
     private final boolean runDetached;
-    private final boolean killProcess;
 
-    public AwsGatlingExecutor(String host,String sshUser, File sshPrivateKey, String testName, File installScript, File gatlingSourceDir, String gatlingSimulation, File simulationConfig, File gatlingResourcesDir, File gatlingLocalResultsDir, List<String> additionalFiles, int numInstance, int instanceCount, ConcurrentHashMap<String, Integer> completedHosts, String gatlingRoot, String inheritedGatlingJavaOpts, boolean debugOutputEnabled, boolean runDetached, boolean killProcess) {
+    public AwsGatlingExecutor(final String host,final String sshUser, final File sshPrivateKey, final String testName, final File installScript, final File gatlingSourceDir, final String gatlingSimulation, final File simulationConfig, final File gatlingResourcesDir, final File gatlingLocalResultsDir, final List<String> additionalFiles, final int numInstance, final int instanceCount, final ConcurrentHashMap<String, Integer> completedHosts, final String gatlingRoot, final String inheritedGatlingJavaOpts, final boolean debugOutputEnabled, final boolean runDetached) {
         this.host = host;
         this.sshUser = sshUser;
         this.sshPrivateKey = sshPrivateKey.getAbsolutePath();
@@ -54,69 +53,64 @@ public class AwsGatlingExecutor implements Runnable {
         this.inheritedGatlingJavaOpts = inheritedGatlingJavaOpts;
         this.debugOutputEnabled = debugOutputEnabled;
         this.runDetached = runDetached;
-        this.killProcess = killProcess;
     }
 
     public void runGatlingTest() throws IOException {
-        log("started");
-        final SshClient.HostInfo hostInfo = new SshClient.HostInfo(host, sshUser, sshPrivateKey);
+        this.log("started");
+        final SshClient.HostInfo hostInfo = new SshClient.HostInfo(this.host, this.sshUser, this.sshPrivateKey);
 
         int resultCode = -1;
-        if (!killProcess) {
-            resultCode = this.runProcess(hostInfo);
-        } else {
-            resultCode = this.killProcess(hostInfo);
-        }
+        resultCode = this.runProcess(hostInfo);
 
         // Indicate success to the caller. This key will be missing from the map if there were any exceptions.
-        completedHosts.put(host, resultCode);
+        this.completedHosts.put(this.host, resultCode);
     }
 
     private int runProcess(final SshClient.HostInfo hostInfo) throws IOException {
 
         // copy scripts
-        SshClient.scpUpload(hostInfo, new SshClient.FromTo(installScript.getAbsolutePath(), ""));
-        SshClient.executeCommand(hostInfo, "chmod +x install-gatling.sh; ./install-gatling.sh", debugOutputEnabled);
+        SshClient.scpUpload(hostInfo, new SshClient.FromTo(this.installScript.getAbsolutePath(), ""));
+        SshClient.executeCommand(hostInfo, "chmod +x install-gatling.sh; ./install-gatling.sh", this.debugOutputEnabled);
         // write information about the instance into a text file to allow the load test to read it if necessary.
-        SshClient.executeCommand(hostInfo, String.format("echo \"num_instance=%s%ninstance_count=%s\" >> instance.txt", numInstance, instanceCount), debugOutputEnabled);
+        SshClient.executeCommand(hostInfo, String.format("echo \"num_instance=%s%ninstance_count=%s\" >> instance.txt", this.numInstance, this.instanceCount), this.debugOutputEnabled);
 
         final List<SshClient.FromTo> files = new ArrayList<>();
-        files.addAll(additionalFiles.stream().map(path -> new SshClient.FromTo(path, "")).collect(Collectors.toList()));
+        files.addAll(this.additionalFiles.stream().map(path -> new SshClient.FromTo(path, "")).collect(Collectors.toList()));
 
         final File targetFolder = new File("target");
-        if (isValidDirectory(targetFolder)) {
-            log("Copying additional JAR files");
+        if (this.isValidDirectory(targetFolder)) {
+            this.log("Copying additional JAR files");
 
-            for (File file : targetFolder.listFiles()) {
-                String path = file.getAbsolutePath();
+            for (final File file : targetFolder.listFiles()) {
+                final String path = file.getAbsolutePath();
                 if (path.endsWith("-jar-with-dependencies.jar")) {
-                    log("Copying JAR file " + path);
-                    files.add(new SshClient.FromTo(path, gatlingRoot + "/lib"));
+                    this.log("Copying JAR file " + path);
+                    files.add(new SshClient.FromTo(path, this.gatlingRoot + "/lib"));
                 }
             }
         }
 
         // copy resource files
-        for (String resource : GATLING_RESOURCES) {
-            log("Copying resource " + resource);
-            String resourceDir = gatlingResourcesDir.getAbsolutePath() + "/" + resource;
-            files.add(new SshClient.FromTo(resourceDir, gatlingRoot + "/user-files"));
+        for (final String resource : GATLING_RESOURCES) {
+            this.log("Copying resource " + resource);
+            final String resourceDir = this.gatlingResourcesDir.getAbsolutePath() + "/" + resource;
+            files.add(new SshClient.FromTo(resourceDir, this.gatlingRoot + "/user-files"));
         }
 
         // copy simulation config
-        files.add(new SshClient.FromTo(simulationConfig.getAbsolutePath(), ""));
+        files.add(new SshClient.FromTo(this.simulationConfig.getAbsolutePath(), ""));
 
         // copy simulation files
-        if (isValidDirectory(gatlingSourceDir)) {
-            log("Copying simulation files");
-            files.addAll(filesToFromToList(gatlingSourceDir.listFiles(), gatlingRoot + "/user-files/simulations"));
+        if (this.isValidDirectory(this.gatlingSourceDir)) {
+            this.log("Copying simulation files");
+            files.addAll(this.filesToFromToList(this.gatlingSourceDir.listFiles(), this.gatlingRoot + "/user-files/simulations"));
         }
 
         // copy simulation gatling configuration files if it exists
         final File configFolder = new File("src/test/resources/conf");
-        if (isValidDirectory(configFolder)) {
-            log("Copying gatling configuration files");
-            files.addAll(filesToFromToList(configFolder.listFiles(), gatlingRoot + "/conf"));
+        if (this.isValidDirectory(configFolder)) {
+            this.log("Copying gatling configuration files");
+            files.addAll(this.filesToFromToList(configFolder.listFiles(), this.gatlingRoot + "/conf"));
         }
 
         // Copy all files via a single SCP session.
@@ -124,49 +118,41 @@ public class AwsGatlingExecutor implements Runnable {
 
         // start test
         // TODO add parameters for test name and description
-        final String coreCommand = String.format("%s %s/bin/gatling.sh -s %s -on %s -rd test -nr -rf results/%s", getJavaOpts(), gatlingRoot, gatlingSimulation, testName, testName);
-        final String command = String.format("%s%s%s", (runDetached ? "nohup sh -c '" : ""), coreCommand, (runDetached ? "' &> /dev/null & sleep 5 && echo $(/sbin/pidof java) > gatling.pid" : ""));
-        int resultCode = SshClient.executeCommand(hostInfo, command, debugOutputEnabled);
+        final String coreCommand = String.format("%s %s/bin/gatling.sh -s %s -on %s -rd test -nr -rf results/%s", this.getJavaOpts(), this.gatlingRoot, this.gatlingSimulation, this.testName, this.testName);
+        final String command = String.format("%s%s%s", (this.runDetached ? "nohup sh -c '" : ""), coreCommand, (this.runDetached ? "' &> /dev/null &" : ""));
+        final int resultCode = SshClient.executeCommand(hostInfo, command, this.debugOutputEnabled);
 
         if (!this.runDetached) {
             // download report
-            log(testName);
+            this.log(this.testName);
             SshClient.executeCommand(hostInfo,
-                    String.format("mv %s/results/%s/*/simulation.log simulation.log", gatlingRoot, testName),
-                    debugOutputEnabled);
+                    String.format("mv %s/results/%s/*/simulation.log simulation.log", this.gatlingRoot, this.testName),
+                    this.debugOutputEnabled);
             SshClient.scpDownload(hostInfo, new SshClient.FromTo("simulation.log",
-                    String.format("%s/%s/simulation-%s.log", gatlingLocalResultsDir.getAbsolutePath(), testName, host)));
+                    String.format("%s/%s/simulation-%s.log", this.gatlingLocalResultsDir.getAbsolutePath(), this.testName, this.host)));
         }
 
-        return resultCode;
-    }
-
-    private int killProcess(final SshClient.HostInfo hostInfo) throws IOException {
-        int resultCode = SshClient.executeCommand(hostInfo,"kill `cat gatling.pid`", debugOutputEnabled);
-        if (resultCode == 1) {
-            resultCode = SshClient.executeCommand(hostInfo, "rm gatling.pid", debugOutputEnabled);
-        }
         return resultCode;
     }
 
     private String getJavaOpts() {
-        return String.format("JAVA_OPTS=\"%s %s\"", DEFAULT_JVM_ARGS, inheritedGatlingJavaOpts);
+        return String.format("JAVA_OPTS=\"%s %s\"", DEFAULT_JVM_ARGS, this.inheritedGatlingJavaOpts);
     }
 
-    private void log(String message) {
-        if (debugOutputEnabled) {
-            System.out.format("%s > %s%n", host, message);
+    private void log(final String message) {
+        if (this.debugOutputEnabled) {
+            System.out.format("%s > %s%n", this.host, message);
         }
     }
 
-    private boolean isValidDirectory(File directory) {
+    private boolean isValidDirectory(final File directory) {
         return directory.exists() && directory.isDirectory() && directory.listFiles() != null && directory.listFiles().length > 0;
     }
 
     public void run() {
         try {
             this.runGatlingTest();
-        } catch (IOException e) {
+        } catch (final IOException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/ea/gatling/AwsGatlingExecutor.java
+++ b/src/main/java/com/ea/gatling/AwsGatlingExecutor.java
@@ -119,7 +119,8 @@ public class AwsGatlingExecutor implements Runnable {
         // start test
         // TODO add parameters for test name and description
         final String coreCommand = String.format("%s %s/bin/gatling.sh -s %s -on %s -rd test -nr -rf results/%s", this.getJavaOpts(), this.gatlingRoot, this.gatlingSimulation, this.testName, this.testName);
-        final String command = String.format("%s%s%s", (this.runDetached ? "nohup sh -c '" : ""), coreCommand, (this.runDetached ? "' &> /dev/null &" : ""));
+        // On CentOS, the CLOSE signal is sent prior to completion of the startup of the nohup.  The sleep call needs the return value of the &, and so causes the wait.  We don't need to sleep, but we do need to guarantee process creation.
+        final String command = String.format("%s%s%s", (this.runDetached ? "nohup sh -c '" : ""), coreCommand, (this.runDetached ? "' > /dev/null 2>&1 & sleep 0" : ""));
         final int resultCode = SshClient.executeCommand(hostInfo, command, this.debugOutputEnabled);
 
         if (!this.runDetached) {

--- a/src/main/java/com/ea/gatling/AwsGatlingRunner.java
+++ b/src/main/java/com/ea/gatling/AwsGatlingRunner.java
@@ -34,14 +34,13 @@ public class AwsGatlingRunner {
                 new SystemPropertiesCredentialsProvider(),
                 new ProfileCredentialsProvider(),
                 new InstanceProfileCredentialsProvider());
-        ec2client = new AmazonEC2Client(credentials);
-        ec2client.setEndpoint(endpoint);
-        transferManager = new TransferManager(credentials);
+        this.ec2client = new AmazonEC2Client(credentials);
+        this.ec2client.setEndpoint(endpoint);
+        this.transferManager = new TransferManager(credentials);
     }
 
     public Map<String, Instance> launchEC2Instances(final String instanceType, final int instanceCount, final String ec2KeyPairName, final String ec2SecurityGroup, final String amiId, final boolean createIfNonExistent) {
-        System.out.println(String.format("Did not find any existing instances, starting new ones with security group: '%s'", ec2SecurityGroup));
-        return launchEC2Instances(instanceType,
+        return this.launchEC2Instances(instanceType,
                 () -> new RunInstancesRequest()
                         .withImageId(amiId)
                         .withInstanceType(instanceType)
@@ -54,8 +53,7 @@ public class AwsGatlingRunner {
     }
 
     public Map<String, Instance> launchEC2Instances(final String instanceType, final int instanceCount, final String ec2KeyPairName, final String ec2SecurityGroupId, final String ec2SubnetId, final String amiId, final boolean createIfNonExistent) {
-        System.out.println(String.format("Did not find any existing instances, starting new ones with security group id: '%s' and subnet: '%s'", ec2SecurityGroupId, ec2SubnetId));
-        return launchEC2Instances(instanceType,
+        return this.launchEC2Instances(instanceType,
                 () -> new RunInstancesRequest()
                         .withImageId(amiId)
                         .withInstanceType(instanceType)
@@ -68,53 +66,63 @@ public class AwsGatlingRunner {
         );
     }
 
-    private Map<String, Instance> launchEC2Instances(String instanceType, RunInstancesRequestBuilder runInstancesRequestBuilder, boolean createIfNonExistent) {
-        Map<String, Instance> instances = new HashMap<>();
+    public Map<String, Instance> findExistingInstances(final String instanceType) {
+        final Map<String, Instance> instances = new HashMap<>();
 
-        DescribeInstancesResult describeInstancesResult = ec2client.describeInstances(new DescribeInstancesRequest()
-                .withFilters(getInstanceFilters(instanceType)));
+        final DescribeInstancesResult describeInstancesResult = this.ec2client.describeInstances(new DescribeInstancesRequest()
+                .withFilters(this.getInstanceFilters(instanceType)));
 
         // Check for existing EC2 instances that fit the filter criteria and use those.
-        for (Reservation reservation : describeInstancesResult.getReservations()) {
-            for (Instance instance : reservation.getInstances()) {
+        for (final Reservation reservation : describeInstancesResult.getReservations()) {
+            for (final Instance instance : reservation.getInstances()) {
                 // If we found any existing EC2 instances put them into the instances variable.
                 System.out.format("Reservations %s (%s): %s%n", instance.getInstanceId(), instance.getState().getName(), instance.getSecurityGroups().get(0).getGroupName());
                 instances.put(instance.getInstanceId(), instance);
             }
         }
 
+        return instances;
+    }
+
+    private Map<String, Instance> launchEC2Instances(final String instanceType, final RunInstancesRequestBuilder runInstancesRequestBuilder, final boolean createIfNonExistent) {
+        final Map<String, Instance> instances = this.findExistingInstances(instanceType);
+
         // If instances is empty, that means we did not find any to reuse so let's create them
         if (instances.isEmpty() && createIfNonExistent) {
-            RunInstancesResult runInstancesResult = ec2client.runInstances(runInstancesRequestBuilder.build());
+            final RunInstancesRequest request = runInstancesRequestBuilder.build();
+            System.out.println(String.format(
+                    "Did not find any existing instances, starting new ones with security group: '%s' and subnet: '%s'",
+                    request.getSecurityGroups().get(0), request.getSubnetId() == null ? "" : request.getSubnetId()));
+            final RunInstancesResult runInstancesResult = this.ec2client.runInstances(request);
 
-            for (Instance instance : runInstancesResult.getReservation().getInstances()) {
+            for (final Instance instance : runInstancesResult.getReservation().getInstances()) {
                 System.out.println(instance.getInstanceId() + " launched");
                 instances.put(instance.getInstanceId(), instance);
             }
 
             // Tag instances on creation. Adding the tag enables us to ensure we are terminating a load generator instance.
-            ec2client.createTags(new CreateTagsRequest()
+            this.ec2client.createTags(new CreateTagsRequest()
                     .withResources(instances.keySet())
-                    .withTags(instanceTag));
+                    .withTags(this.instanceTag));
 
-            DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(instances.keySet());
+            final DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(instances.keySet());
 
-            startAllInstances(instances, describeInstancesRequest);
+            this.startAllInstances(instances, describeInstancesRequest);
         }
 
         return instances;
     }
 
-    private void startAllInstances(Map<String, Instance> instances, DescribeInstancesRequest describeInstancesRequest) {
+    private void startAllInstances(final Map<String, Instance> instances, final DescribeInstancesRequest describeInstancesRequest) {
         boolean allStarted = false;
         DescribeInstancesResult describeInstancesResult;
 
         while (!allStarted) {
             sleep(INSTANCE_STATUS_SLEEP_MS);
             allStarted = true;
-            describeInstancesResult = ec2client.describeInstances(describeInstancesRequest);
-            for (Reservation reservation : describeInstancesResult.getReservations()) {
-                for (Instance instance : reservation.getInstances()) {
+            describeInstancesResult = this.ec2client.describeInstances(describeInstancesRequest);
+            for (final Reservation reservation : describeInstancesResult.getReservations()) {
+                for (final Instance instance : reservation.getInstances()) {
                     System.out.format("%s %s%n", instance.getInstanceId(), instance.getState().getName());
                     if (!instance.getState().getName().equals("running")) {
                         allStarted = false;
@@ -124,13 +132,13 @@ public class AwsGatlingRunner {
                 }
             }
 
-            DescribeInstanceStatusRequest describeInstanceStatusRequest = new DescribeInstanceStatusRequest().withInstanceIds(instances.keySet());
+            final DescribeInstanceStatusRequest describeInstanceStatusRequest = new DescribeInstanceStatusRequest().withInstanceIds(instances.keySet());
             boolean allInitialized = false;
             while (!allInitialized) {
                 sleep(INSTANCE_STATUS_SLEEP_MS);
-                DescribeInstanceStatusResult describeInstanceStatus = ec2client.describeInstanceStatus(describeInstanceStatusRequest);
+                final DescribeInstanceStatusResult describeInstanceStatus = this.ec2client.describeInstanceStatus(describeInstanceStatusRequest);
                 allInitialized = true;
-                for (InstanceStatus instanceStatus : describeInstanceStatus.getInstanceStatuses()) {
+                for (final InstanceStatus instanceStatus : describeInstanceStatus.getInstanceStatuses()) {
                     System.out.format("%s %s%n", instanceStatus.getInstanceId(), instanceStatus.getInstanceStatus().getStatus());
                     if (!instanceStatus.getInstanceStatus().getStatus().equals("ok")) {
                         allInitialized = false;
@@ -140,21 +148,21 @@ public class AwsGatlingRunner {
         }
     }
 
-    private Filter[] getInstanceFilters(String instanceType) {
+    private Filter[] getInstanceFilters(final String instanceType) {
         // Setup a filter to find any previously generated EC2 instances.
         return new Filter[]{
-            new Filter("tag:" + instanceTag.getKey()).withValues(instanceTag.getValue()),
+            new Filter("tag:" + this.instanceTag.getKey()).withValues(this.instanceTag.getValue()),
             new Filter("instance-state-name").withValues("running"),
             new Filter("instance-type").withValues(instanceType)
         };
     }
 
-    public void terminateInstances(Collection<String> instanceIds) {
-        DescribeInstancesResult describeInstancesResult = ec2client.describeInstances(new DescribeInstancesRequest().withInstanceIds(instanceIds));
+    public void terminateInstances(final Collection<String> instanceIds) {
+        final DescribeInstancesResult describeInstancesResult = this.ec2client.describeInstances(new DescribeInstancesRequest().withInstanceIds(instanceIds));
 
-        for (Reservation reservation : describeInstancesResult.getReservations()) {
-            for (Instance instance : reservation.getInstances()) {
-                if (!hasTag(instance, instanceTag)) {
+        for (final Reservation reservation : describeInstancesResult.getReservations()) {
+            for (final Instance instance : reservation.getInstances()) {
+                if (!this.hasTag(instance, this.instanceTag)) {
                     System.out.format("Aborting since instance %s does not look like a gatling load generator.%n", instance.getInstanceId());
                     return;
                 }
@@ -163,27 +171,27 @@ public class AwsGatlingRunner {
         }
 
         System.out.println("Terminating " + instanceIds);
-        ec2client.terminateInstances(new TerminateInstancesRequest(new ArrayList<String>(instanceIds)));
+        this.ec2client.terminateInstances(new TerminateInstancesRequest(new ArrayList<String>(instanceIds)));
     }
 
-    public void uploadToS3(String s3bucket, String targetDirectory, File sourceDirectory) {
+    public void uploadToS3(final String s3bucket, final String targetDirectory, final File sourceDirectory) {
         // Recursively upload sourceDirectory to targetDirectory.
         FOR: for (final File file : sourceDirectory.listFiles()) {
             if (file.isDirectory()) {
-                uploadToS3(s3bucket, targetDirectory + "/" + file.getName(), file);
+                this.uploadToS3(s3bucket, targetDirectory + "/" + file.getName(), file);
             } else if (file.isFile()) {
                 final String path = file.getAbsolutePath();
                 final long uploadStartTimeMs = System.currentTimeMillis();
                 final PutObjectRequest putRequest = new PutObjectRequest(s3bucket, targetDirectory + "/" + file.getName(), file)
                         .withCannedAcl(CannedAccessControlList.PublicRead);
 
-                final Upload upload = transferManager.upload(putRequest);
+                final Upload upload = this.transferManager.upload(putRequest);
                 int statusChecks = 0;
 
                 System.out.println("Uploading " + path);
 
                 while (!upload.isDone()) {
-                    if (uploadTimedOut(uploadStartTimeMs)) {
+                    if (this.uploadTimedOut(uploadStartTimeMs)) {
                         System.err.format("Timed out uploading file to S3 (%s). Will skip file. Report might be incomplete.%n", path);
                         continue FOR;
                     }
@@ -195,7 +203,7 @@ public class AwsGatlingRunner {
                 }
                 try {
                     upload.waitForCompletion();
-                } catch (Exception e) {
+                } catch (final Exception e) {
                     System.out.format("Failed to upload to S3 %s/%s/%s%n", s3bucket, targetDirectory, file.getName());
                     e.printStackTrace();
                 }
@@ -211,8 +219,8 @@ public class AwsGatlingRunner {
         return totalUploadTimeMs > S3_UPLOAD_TIMEOUT_MS;
     }
 
-    private boolean hasTag(Instance instance, Tag theTag) {
-        for (Tag tag : instance.getTags()) {
+    private boolean hasTag(final Instance instance, final Tag theTag) {
+        for (final Tag tag : instance.getTags()) {
             if (tag.equals(theTag)) {
                 return true;
             }
@@ -225,10 +233,10 @@ public class AwsGatlingRunner {
         this.instanceTag = instanceTag;
     }
 
-    private void sleep(long timeMs) {
+    private void sleep(final long timeMs) {
         try {
             Thread.sleep(timeMs);
-        } catch (InterruptedException e) {
+        } catch (final InterruptedException e) {
         }
     }
 

--- a/src/main/java/com/ea/gatling/BaseAwsMojo.java
+++ b/src/main/java/com/ea/gatling/BaseAwsMojo.java
@@ -40,4 +40,10 @@ public abstract class BaseAwsMojo extends AbstractMojo {
     @Parameter(property = "ec2.tag.value", defaultValue = "Gatling Load Generator")
     protected String ec2TagValue;
 
+    @Parameter(property = "ec2.force.termination", defaultValue = "false")
+    protected boolean ec2ForceTermination = false;
+
+    // This parameter, when set to true, will override the ec2ForceTermination and allow the EC2 instance to continue running for reuse
+    @Parameter(property = "ec2.keep.alive", defaultValue="false")
+    protected boolean ec2KeepAlive = false;
 }

--- a/src/main/java/com/ea/gatling/BaseAwsMojo.java
+++ b/src/main/java/com/ea/gatling/BaseAwsMojo.java
@@ -1,0 +1,43 @@
+package com.ea.gatling;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+public abstract class BaseAwsMojo extends AbstractMojo {
+    @Parameter(property = "ec2.instance.count", defaultValue = "1")
+    protected Integer instanceCount;
+
+    @Parameter(property = "ec2.instance.type", defaultValue = "m3.medium")
+    protected String instanceType;
+
+    /**
+     * ID of the Amazon Machine Image to be used. Defaults to Amazon Linux.
+     */
+    @Parameter(property = "ec2.ami.id", defaultValue = "ami-b66ed3de")
+    protected String ec2AmiId;
+
+    @Parameter(property = "ec2.key.pair.name", defaultValue = "gatling-key-pair")
+    protected String ec2KeyPairName;
+
+    /**
+     * Create a security group for the Gatling EC2 instances. Ensure it allows inbound SSH traffic to your IP address range.
+     */
+    @Parameter(property = "ec2.security.group", defaultValue = "gatling-security-group")
+    protected String ec2SecurityGroup;
+
+    @Parameter(property = "ec2.security.group.id")
+    protected String ec2SecurityGroupId;
+
+    @Parameter(property = "ec2.subnet.id")
+    protected String ec2SubnetId;
+
+    @Parameter(property = "ec2.end.point", defaultValue="https://ec2.us-east-1.amazonaws.com")
+    protected String ec2EndPoint;
+
+    @Parameter(property = "ec2.tag.name", defaultValue = "Name")
+    protected String ec2TagName;
+
+    @Parameter(property = "ec2.tag.value", defaultValue = "Gatling Load Generator")
+    protected String ec2TagValue;
+
+}

--- a/src/main/java/com/ea/gatling/GatlingAwsMojo.java
+++ b/src/main/java/com/ea/gatling/GatlingAwsMojo.java
@@ -95,13 +95,6 @@ public class GatlingAwsMojo extends BaseAwsMojo {
     @Parameter(property = "prefer.private.ip.hostnames", defaultValue = "false")
     private boolean preferPrivateIpHostnames;
 
-    @Parameter(property = "ec2.force.termination", defaultValue = "false")
-    private boolean ec2ForceTermination = false;
-
-    // This parameter, when set to true, will override the ec2ForceTermination and allow the EC2 instance to continue running for reuse
-    @Parameter(property = "ec2.keep.alive", defaultValue="false")
-    private boolean ec2KeepAlive = false;
-
     /**
      * When true, this will run Gatling detached, and disconnect from SSH while Gatling is running.  Leaves a
      *    file called 'gatling.pid' with the pid of the java process in it.

--- a/src/main/java/com/ea/gatling/GatlingAwsMojo.java
+++ b/src/main/java/com/ea/gatling/GatlingAwsMojo.java
@@ -6,7 +6,6 @@ package com.ea.gatling;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Tag;
 
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -27,73 +26,11 @@ import java.util.concurrent.Executors;
  * Runs gatling script on remote EC2 instances.
  */
 @Mojo(name = "execute")
-public class GatlingAwsMojo extends AbstractMojo {
+public class GatlingAwsMojo extends BaseAwsMojo {
     /**
      * The time in milliseconds between checking for the termination of all executors running load tests.
      */
     private static final int SLEEP_TIME_TERMINATION_MS = 1000;
-
-    @Parameter(property = "ec2.instance.count", defaultValue = "1")
-    private Integer instanceCount;
-
-    @Parameter(property = "ec2.instance.type", defaultValue = "m3.medium")
-    private String instanceType;
-
-    /**
-     * ID of the Amazon Machine Image to be used. Defaults to Amazon Linux.
-     */
-    @Parameter(property = "ec2.ami.id", defaultValue = "ami-b66ed3de")
-    private String ec2AmiId;
-
-    @Parameter(property = "ec2.key.pair.name", defaultValue = "gatling-key-pair")
-    private String ec2KeyPairName;
-
-    /**
-     * Create a security group for the Gatling EC2 instances. Ensure it allows inbound SSH traffic to your IP address range.
-     */
-    @Parameter(property = "ec2.security.group", defaultValue = "gatling-security-group")
-    private String ec2SecurityGroup;
-
-    @Parameter(property = "ec2.security.group.id")
-    private String ec2SecurityGroupId;
-
-    @Parameter(property = "ec2.subnet.id")
-    private String ec2SubnetId;
-
-    @Parameter(property = "ec2.force.termination", defaultValue = "false")
-    private boolean ec2ForceTermination = false;
-
-    // This parameter, when set to true, will override the ec2ForceTermination and allow the EC2 instance to continue running for reuse
-    @Parameter(property = "ec2.keep.alive", defaultValue="false")
-    private boolean ec2KeepAlive = false;
-
-    /**
-     * When true, this will run Gatling detached, and disconnect from SSH while Gatling is running.  Leaves a
-     *    file called 'gatling.pid' with the pid of the java process in it.
-     * ec2.keep.alive ignored when set to true
-     * ec2.force.termination ignored when set to true
-     * All output turned off
-     */
-    @Parameter(property = "ec2.execute.detached", defaultValue = "false")
-    private boolean ec2ExecuteDetached = false;
-
-    /**
-     * When true, if a 'gatling.pid' file is found, then the pid will be killed.  This is to be used in conjunction with
-     *    'ec2.execute.detached' to allow the process to be killed easily.
-     * Only ec2 connect variables will be used.
-     * ignores ec2.execute.detached
-     */
-    @Parameter(property = "ec2.kill.process", defaultValue = "false")
-    private boolean ec2KillProcess;
-
-    @Parameter(property = "ec2.end.point", defaultValue="https://ec2.us-east-1.amazonaws.com")
-    private String ec2EndPoint;
-
-    @Parameter(property = "ec2.tag.name", defaultValue = "Name")
-    private String ec2TagName;
-
-    @Parameter(property = "ec2.tag.value", defaultValue = "Gatling Load Generator")
-    private String ec2TagValue;
 
     @Parameter(property = "ssh.private.key", defaultValue = "${user.home}/gatling-private-key.pem")
     private File sshPrivateKey;
@@ -158,48 +95,65 @@ public class GatlingAwsMojo extends AbstractMojo {
     @Parameter(property = "prefer.private.ip.hostnames", defaultValue = "false")
     private boolean preferPrivateIpHostnames;
 
-    public void execute() throws MojoExecutionException {
-        AwsGatlingRunner runner = new AwsGatlingRunner(ec2EndPoint);
-        runner.setInstanceTag(new Tag(ec2TagName, ec2TagValue));
+    @Parameter(property = "ec2.force.termination", defaultValue = "false")
+    private boolean ec2ForceTermination = false;
 
-        Map<String, Instance> instances = ec2SecurityGroupId != null
-                ? runner.launchEC2Instances(instanceType, instanceCount, ec2KeyPairName, ec2SecurityGroupId, ec2SubnetId, ec2AmiId, !ec2KillProcess)
-                : runner.launchEC2Instances(instanceType, instanceCount, ec2KeyPairName, ec2SecurityGroup, ec2AmiId, !ec2KillProcess);
-        ConcurrentHashMap<String, Integer> completedHosts = new ConcurrentHashMap<String, Integer>();
+    // This parameter, when set to true, will override the ec2ForceTermination and allow the EC2 instance to continue running for reuse
+    @Parameter(property = "ec2.keep.alive", defaultValue="false")
+    private boolean ec2KeepAlive = false;
+
+    /**
+     * When true, this will run Gatling detached, and disconnect from SSH while Gatling is running.  Leaves a
+     *    file called 'gatling.pid' with the pid of the java process in it.
+     * ec2.keep.alive ignored when set to true
+     * ec2.force.termination ignored when set to true
+     * All output turned off
+     */
+    @Parameter(property = "ec2.execute.detached", defaultValue = "false")
+    private boolean ec2ExecuteDetached = false;
+
+
+    public void execute() throws MojoExecutionException {
+        final AwsGatlingRunner runner = new AwsGatlingRunner(this.ec2EndPoint);
+        runner.setInstanceTag(new Tag(this.ec2TagName, this.ec2TagValue));
+
+        final Map<String, Instance> instances = this.ec2SecurityGroupId != null
+                ? runner.launchEC2Instances(this.instanceType, this.instanceCount, this.ec2KeyPairName, this.ec2SecurityGroupId, this.ec2SubnetId, this.ec2AmiId, true)
+                : runner.launchEC2Instances(this.instanceType, this.instanceCount, this.ec2KeyPairName, this.ec2SecurityGroup, this.ec2AmiId, true);
+        final ConcurrentHashMap<String, Integer> completedHosts = new ConcurrentHashMap<>();
 
         // launch all tests in parallel
-        ExecutorService executor = Executors.newFixedThreadPool(instanceCount);
+        final ExecutorService executor = Executors.newFixedThreadPool(this.instanceCount);
 
-        long timeStamp = System.currentTimeMillis();
-        testName = testName.equals("") ? gatlingSimulation.toLowerCase() + "-" + timeStamp : testName + "-" + timeStamp;
-        File resultsDir = new File(gatlingLocalResultsDir, testName);
-        boolean success = resultsDir.mkdirs();
+        final long timeStamp = System.currentTimeMillis();
+        this.testName = this.testName.equals("") ? this.gatlingSimulation.toLowerCase() + "-" + timeStamp : this.testName + "-" + timeStamp;
+        final File resultsDir = new File(this.gatlingLocalResultsDir, this.testName);
+        final boolean success = resultsDir.mkdirs();
         System.out.format("created result dir %s: %s%n", resultsDir.getAbsolutePath(), success);
 
-        Collection<Instance> values = instances.values();
+        final Collection<Instance> values = instances.values();
         int numInstance = 0;
-        for (Instance instance : values) {
-            String host = getPreferredHostName(instance);
-            Runnable worker = new AwsGatlingExecutor(
+        for (final Instance instance : values) {
+            final String host = this.getPreferredHostName(instance);
+            final Runnable worker = new AwsGatlingExecutor(
                     host,
-                    sshUser,
-                    sshPrivateKey,
-                    testName,
-                    installScript,
-                    gatlingSourceDir,
-                    gatlingSimulation,
-                    simulationConfig,
-                    gatlingResourcesDir,
-                    gatlingLocalResultsDir,
-                    files,
+                    this.sshUser,
+                    this.sshPrivateKey,
+                    this.testName,
+                    this.installScript,
+                    this.gatlingSourceDir,
+                    this.gatlingSimulation,
+                    this.simulationConfig,
+                    this.gatlingResourcesDir,
+                    this.gatlingLocalResultsDir,
+                    this.files,
                     numInstance++,
-                    instanceCount,
+                    this.instanceCount,
                     completedHosts,
-                    gatlingRoot,
-                    gatlingJavaOpts,
-                    debugOutputEnabled,
-                    ec2ExecuteDetached,
-                    ec2KillProcess);
+                    this.gatlingRoot,
+                    this.gatlingJavaOpts,
+                    this.debugOutputEnabled,
+                    this.ec2ExecuteDetached);
             executor.execute(worker);
         }
         executor.shutdown();
@@ -207,84 +161,84 @@ public class GatlingAwsMojo extends AbstractMojo {
         while (!executor.isTerminated()) {
             try {
                 Thread.sleep(SLEEP_TIME_TERMINATION_MS);
-            } catch (InterruptedException e) {
+            } catch (final InterruptedException e) {
             }
         }
         System.out.println("Finished all threads");
 
-        int failedInstancesCount = listFailedInstances(instances, completedHosts);
+        final int failedInstancesCount = this.listFailedInstances(instances, completedHosts);
 
         // If the ec2KeepAlive value is true then we need to skip terminating.
-        if ((failedInstancesCount == 0 || ec2ForceTermination) && !ec2KeepAlive && (!ec2ExecuteDetached || ec2KillProcess)) {
+        if ((failedInstancesCount == 0 || this.ec2ForceTermination) && !this.ec2KeepAlive && !this.ec2ExecuteDetached) {
             runner.terminateInstances(instances.keySet());
-        } else if (ec2KeepAlive) {
+        } else if (this.ec2KeepAlive) {
             // Send a message out stating the machines are still running
             System.out.println("EC2 instances are still running for the next load test");
-        } else if (ec2ExecuteDetached) {
+        } else if (this.ec2ExecuteDetached) {
             System.out.println("EC2 instances are running detached");
         }
 
-        if (!ec2ExecuteDetached && !ec2KillProcess) {
+        if (!this.ec2ExecuteDetached) {
             // Build report
-            String reportCommand = String.format("%s -ro %s/%s", gatlingLocalHome, gatlingLocalResultsDir, testName);
+            final String reportCommand = String.format("%s -ro %s/%s", this.gatlingLocalHome, this.gatlingLocalResultsDir, this.testName);
             System.out.format("Report command: %s%n", reportCommand);
-            System.out.println(executeCommand(reportCommand));
+            System.out.println(this.executeCommand(reportCommand));
 
             // Upload report to S3
-            if (s3UploadEnabled) {
-                System.out.format("Trying to upload simulation to S3 location %s/%s/%s%n", s3Bucket, s3Subfolder,
-                        testName);
-                runner.uploadToS3(s3Bucket, s3Subfolder + "/" + testName,
-                        new File(gatlingLocalResultsDir + File.separator + testName));
+            if (this.s3UploadEnabled) {
+                System.out.format("Trying to upload simulation to S3 location %s/%s/%s%n", this.s3Bucket, this.s3Subfolder,
+                        this.testName);
+                runner.uploadToS3(this.s3Bucket, this.s3Subfolder + "/" + this.testName,
+                        new File(this.gatlingLocalResultsDir + File.separator + this.testName));
 
-                final String url = getS3Url();
+                final String url = this.getS3Url();
                 System.out.format("Results are on %s%n", url);
 
                 try {
                     // Write the results URL into a file. This provides the URL to external tools which might want to link to the results.
                     FileUtils.fileWrite("results.txt", url);
-                } catch (IOException e) {
+                } catch (final IOException e) {
                     System.err.println("Can't write result address: " + e);
                 }
             } else {
                 System.out.println("Skipping upload to S3.");
             }
         } else {
-            System.out.println("Running detached or killing detached process, no reports available.");
+            System.out.println("Running detached, no reports available.");
         }
 
-        if (propagateGatlingFailure && failedInstancesCount > 0) {
+        if (this.propagateGatlingFailure && failedInstancesCount > 0) {
             throw new MojoExecutionException("Some gatling simulation failed: " + failedInstancesCount);
         }
     }
 
     private String getS3Url() {
-        if ("us-east-1".equalsIgnoreCase(s3Region)) {
+        if ("us-east-1".equalsIgnoreCase(this.s3Region)) {
             // us-east-1 has no prefix - http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
-            return String.format("https://s3.amazonaws.com/%s/%s/%s/index.html", s3Bucket, s3Subfolder, testName);
+            return String.format("https://s3.amazonaws.com/%s/%s/%s/index.html", this.s3Bucket, this.s3Subfolder, this.testName);
         }
-        return String.format("https://s3-%s.amazonaws.com/%s/%s/%s/index.html", s3Region, s3Bucket, s3Subfolder, testName);
+        return String.format("https://s3-%s.amazonaws.com/%s/%s/%s/index.html", this.s3Region, this.s3Bucket, this.s3Subfolder, this.testName);
     }
 
-    private String executeCommand(String command) {
-        StringBuffer output = new StringBuffer();
+    private String executeCommand(final String command) {
+        final StringBuffer output = new StringBuffer();
 
         try {
-            Process process = Runtime.getRuntime().exec(command);
-            int exitCode = process.waitFor();
+            final Process process = Runtime.getRuntime().exec(command);
+            final int exitCode = process.waitFor();
             SshClient.printExitCode(exitCode);
 
-            output.append(read(new BufferedReader(new InputStreamReader(process.getInputStream()))));
-            output.append(read(new BufferedReader(new InputStreamReader(process.getErrorStream()))));
-        } catch (Exception e) {
+            output.append(this.read(new BufferedReader(new InputStreamReader(process.getInputStream()))));
+            output.append(this.read(new BufferedReader(new InputStreamReader(process.getErrorStream()))));
+        } catch (final Exception e) {
             e.printStackTrace();
         }
 
         return output.toString();
     }
 
-    private StringBuffer read(BufferedReader reader) throws IOException {
-        StringBuffer output = new StringBuffer();
+    private StringBuffer read(final BufferedReader reader) throws IOException {
+        final StringBuffer output = new StringBuffer();
         String line;
 
         while ((line = reader.readLine()) != null) {
@@ -295,11 +249,11 @@ public class GatlingAwsMojo extends AbstractMojo {
         return output;
     }
 
-    private int listFailedInstances(Map<String, Instance> instances, ConcurrentHashMap<String, Integer> completedHosts) {
+    private int listFailedInstances(final Map<String, Instance> instances, final ConcurrentHashMap<String, Integer> completedHosts) {
         int failedInstancesCount = instances.size() - completedHosts.size();
 
-        for (Instance instance : instances.values()) {
-            String host = getPreferredHostName(instance);
+        for (final Instance instance : instances.values()) {
+            final String host = this.getPreferredHostName(instance);
 
             if (!completedHosts.containsKey(host)) {
                 System.out.format("No result collected from hostname: %s%n", host);
@@ -314,8 +268,8 @@ public class GatlingAwsMojo extends AbstractMojo {
         return failedInstancesCount;
     }
 
-    private String getPreferredHostName(Instance instance) {
-        if (preferPrivateIpHostnames) {
+    private String getPreferredHostName(final Instance instance) {
+        if (this.preferPrivateIpHostnames) {
             return instance.getPrivateIpAddress();
         }
 

--- a/src/main/java/com/ea/gatling/KillGatlingAwsMojo.java
+++ b/src/main/java/com/ea/gatling/KillGatlingAwsMojo.java
@@ -1,0 +1,26 @@
+package com.ea.gatling;
+
+import java.util.Map;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.Tag;
+
+/**
+ * Kill instances with the tag in "ec2.tag.value"
+ */
+@Mojo(name = "kill")
+public class KillGatlingAwsMojo extends BaseAwsMojo {
+
+    @Override public void execute() throws MojoExecutionException, MojoFailureException {
+        final AwsGatlingRunner runner = new AwsGatlingRunner(this.ec2EndPoint);
+        runner.setInstanceTag(new Tag(this.ec2TagName, this.ec2TagValue));
+
+        final Map<String, Instance> instances = runner.findExistingInstances(this.instanceType);
+
+        runner.terminateInstances(instances.keySet());
+    }
+}


### PR DESCRIPTION
These changes allow running the bots detached from an ssh session.  This would allow long-running bots without the need to monitor.  Logs of the load tests will be ignored, however.  A kill mojo is also added to allow killing the instances running detached, as well as killing any instances left over from an erroneous run.